### PR TITLE
Fix typo in Dockerfile for mermaid syntax highligh extension

### DIFF
--- a/vscode-mermaid-syntax-highlight/Dockerfile
+++ b/vscode-mermaid-syntax-highlight/Dockerfile
@@ -22,5 +22,5 @@ RUN mkdir ./${extension_name}-src && cd ./${extension_name}-src && \
     cd ./${extension_name} && git checkout ${extension_revision} && \
     rm -rf ./.git && tar -czvf /${extension_name}-${extension_revision}-sources.tar.gz ./ && \
     npm install -g vsce gulp-cli && npm install --unsafe-perm=true --allow-root && \
-    npm run convertYaml \
+    npm run convertYaml && \
     vsce package --out /${extension_name}-${extension_revision}.vsix


### PR DESCRIPTION
Signed-off-by: Vitaliy Gulyy <vgulyy@redhat.com>

Fixes typo in command building vsix binary
The original PR https://github.com/redhat-developer/codeready-workspaces-vscode-extensions/pull/11