### PR TITLE
feat(extension): Add vscode commons v0.0.6

### DIFF
--- a/redhat.vscode-commons/extension.json
+++ b/redhat.vscode-commons/extension.json
@@ -1,0 +1,4 @@
+{
+  "repository": "https://github.com/redhat-developer/vscode-commons",
+  "revision": "021b0165bb5ba05e107ee7e31d1e59a7a73f473c"
+}


### PR DESCRIPTION
related to https://github.com/eclipse/che/issues/19361

there is no tag 0.0.6 but the sha1 used is the one that is used for 0.0.6
https://github.com/redhat-developer/vscode-commons/commit/021b0165bb5ba05e107ee7e31d1e59a7a73f473c

Change-Id: I74734205f85a87c9bcbcedc8a123bc8f362c54cb
Signed-off-by: Florent Benoit <fbenoit@redhat.com>