### PR TITLE
fix(vscode-python): Reducing size of ipywidgets.js to fix loading issue of Jupyter Notebooks in che-theia

### DIFF
--- a/vscode-python/Dockerfile
+++ b/vscode-python/Dockerfile
@@ -21,6 +21,9 @@ RUN dnf -y install git python36 python3-six python3-pip platform-python-pip \
     curl wget bzip2 gdb make cmake gcc gcc-c++
 RUN /usr/bin/python3 -m pip install --upgrade pip
 
+# activating CI/production mode to reduce size of webpack output
+ENV TRAVIS=true
+
 RUN mkdir ./${extension_name}-src && cd ./${extension_name}-src && \
     git clone ${extension_repository} ${extension_name} && \
     cd ./${extension_name} && git checkout ${extension_revision} && \


### PR DESCRIPTION
Using env variable TRAVIS to activate production mode: minifying js files like ipywidgets.js.

Quick fix for https://issues.redhat.com/browse/CRW-1857

See details https://issues.redhat.com/browse/CRW-1857?focusedCommentId=19005102&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-19005102


Local build artifact of this PR: https://github.com/sunix/vscode-python/releases/download/crw-2020.7.94776/vscode-python-2020.7.94776.vsix