### PR TITLE
feat: upload artifacts from PR check

### DIFF
--- a/.github/workflows/extension-pr-check.yaml
+++ b/.github/workflows/extension-pr-check.yaml
@@ -27,5 +27,12 @@ jobs:
 
     - name: Build extension
       run: |
-        ./.ci/extension_build_publish.sh build origin/${{ github.base_ref }} ${{ github.event.pull_request.head.sha }}
+        ./.ci/extension_build_publish.sh build-publish origin/${{ github.base_ref }} ${{ github.event.pull_request.head.sha }}
 
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        path: |
+          *.vsix
+          *-sources.tar.gz


### PR DESCRIPTION
Signed-off-by: Mykhailo Kuznietsov <mkuznets@redhat.com>

Improve PR check job, by uploading artifacts (.vsix and sources archive), so that they can be previewed before merging