### PR TITLE
add vscode-task-manager extension

### DIFF
--- a/plugin-config.json
+++ b/plugin-config.json
@@ -245,6 +245,12 @@
       "repository": "https://github.com/xdebug/vscode-php-debug",
       "revision": "v1.32.1",
       "update": "true"
+    },
+    "vscode-task-manager": {
+      "comment": "Provides easy access to devfile commands/tasks",
+      "repository": "https://github.com/cnshenj/vscode-task-manager",
+      "revision": "1.0.0",
+      "update": "true"
     }
   }
 }

--- a/plugin-manifest.json
+++ b/plugin-manifest.json
@@ -169,6 +169,10 @@
     "ms-python.black-formatter": {
       "vsix": "8f5e3a2c4564099986b0c20cfedadf02e7b931412afa62ab061ff2ca19db4cfc",
       "source": "72b64f82661a88ea14148a353a68c99cccf1c45c3a1399e613bba9cf11b05cec"
+    },
+    "vscode-task-manager": {
+      "vsix": "730bdc41bc897b15b375f6f30c0d2f6b786a16b882ed4ac5bd321fec532164d5",
+      "source": "12a5f71d38f1c4411da61cd3338f8be006f8a6af5831ebde443179094d18471c"
     }
   }
 }

--- a/vscode-task-manager/extension.json
+++ b/vscode-task-manager/extension.json
@@ -1,0 +1,4 @@
+{
+  "repository": "https://github.com/cnshenj/vscode-task-manager",
+  "revision": "1.0.0"
+}


### PR DESCRIPTION
This simple extension (https://open-vsx.org/extension/cnshenj/vscode-task-manager) provides easy access to devfile tasks from the main left menu in vscode. With this extension, users don't need to use `Run Task` command to execute a devfile task.