### PR TITLE
feat: add vscode-dotnet-runtime extension

### DIFF
--- a/ms-dotnettools.vscode-dotnet-runtime/Dockerfile
+++ b/ms-dotnettools.vscode-dotnet-runtime/Dockerfile
@@ -1,0 +1,32 @@
+#
+# Copyright (c) 2020 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+ARG extension_image
+
+FROM registry.access.redhat.com/ubi8/${extension_image}
+
+ARG extension_repository
+ARG extension_revision
+ARG extension_name
+ARG extension_manager
+ARG extension_vsce
+
+USER root
+WORKDIR /
+
+RUN npm install -g ${extension_manager}
+
+RUN mkdir ./${extension_name}-src && cd ./${extension_name}-src && \
+    git clone ${extension_repository} ${extension_name} && \
+    cd ./${extension_name} && git checkout ${extension_revision} && \
+    ./build.sh && \
+    cd vscode-dotnet-runtime-extension && \
+    rm -rf ./.git && tar -czvf /${extension_name}-sources.tar.gz ./ && \
+    npm install -g @vscode/vsce@${extension_vsce} && \
+    vsce package --ignoreFile ../.vscodeignore --yarn --out /${extension_name}.vsix

--- a/ms-dotnettools.vscode-dotnet-runtime/Dockerfile
+++ b/ms-dotnettools.vscode-dotnet-runtime/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020 Red Hat, Inc.
+# Copyright (c) 2023 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/plugin-config.json
+++ b/plugin-config.json
@@ -147,6 +147,12 @@
       "revision": "v1.0.3",
       "update": "false"
     },
+    "ms-dotnettools.vscode-dotnet-runtime": {
+      "repository": "https://github.com/dotnet/vscode-dotnet-runtime",
+      "revision": "Runtime-v1.7.2",
+      "packageManager": "yarn@1.22.10",
+      "update": "false"
+    },
     "muhammad-sammy.csharp": {
       "repository": "https://github.com/muhammadsammy/free-omnisharp-vscode",
       "revision": "1.25.7",

--- a/plugin-manifest.json
+++ b/plugin-manifest.json
@@ -173,6 +173,10 @@
     "ms-python.isort": {
       "vsix": "3c2f52f42f8c2c5e90f2bb742c5b5e3c1e0fe9ad8439a370e185cf4e9e023a2b",
       "source": "34ea03f8e3174f7b4472eabdecfae73f8f80567781986dc427fb6726302b7c8c"
+    },
+    "ms-dotnettools.vscode-dotnet-runtime": {
+      "vsix": "789770ff1f4e82f84a352e7c25dba0640990fec0c342c4d60e9554a68af86054",
+      "source": "90aeb93bd4e25876bc2be000ba9e447aaeb25da9011b825c06833a3160e78f67"
     }
   }
 }


### PR DESCRIPTION
Add **ms-dotnettools.vscode-dotnet-runtime** extension to the list and Dockerfile to build it.

Related issue: https://issues.redhat.com/browse/CRW-4835