### PR TITLE
fix: CRW-4859 fix extension builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.vsix
+*.tar.gz

--- a/README.md
+++ b/README.md
@@ -1,19 +1,29 @@
+Links marked with this icon 🚪 are internal to Red Hat
+
 This repository builds and publishes VS Code extensions used in both Eclipse Che and in Red Hat OpenShift Dev Spaces (formerly Red Hat CodeReady Workspaces).
 
-Every extension in this repository builds inside a `ubi8` based Dockerfile. The resulting `.vsix` files and sources tarballs are then copied out of the container and published as GitHub release assets. Every PR merged in this repository will trigger a GitHub release, where the extensions built from that PR will be the release assets in the corresponding GitHub release.
+Every extension in this repository builds inside a `ubi8` based Dockerfile. The resulting `.vsix` files and sources tarballs are then copied out of the container and published as GitHub release assets. Additionally, for DevSpaces a special [Jenkins Job](https://main-jenkins-csb-crwqe.apps.ocp-c1.prod.psi.redhat.com/job/DS_CI/job/pluginregistry-plugins_3.x) is used to publish devspaces  Every PR merged in this repository will trigger a GitHub release, where the extensions built from that PR will be the release assets in the corresponding GitHub release.
 
 # Contributing
 ## Repository Structure
-Every folder in this repository belongs to a VS Code extension. For example, the `Dockerfile` that builds the `vscode-python` extension would live in the `/vscode-python` folder. Please note that the name of the folder **must** match the repository name for the VS Code extension. For example, the folder name for the extension hosted at `https://github.com/microsoft/vscode-eslint` must be named `vscode-eslint`.
+`plugin-config.json` contains information about all VS Code extensions.
+`plugin-manifests.json` contains information about SHA sums for all built plugins, that are published to [RCM tools](https://download.devel.redhat.com/rcm-guest/staging/devspaces/build-requirements/) 🚪. 
 
-Every extension folder **must** have an `extension.json` file at its root. The schema of this JSON file is as follows:
+Every extension  **must** have an entry in `plugin-config.json` file. An example entry of a plugin in JSON is as follows:
 
 ```js
-{
+
+atlassian.atlascode{
   // Repository URL of the extension's git repository
   "repository": "https://github.com/microsoft/vscode-python",
   // The tag/SHA1-ID of the extension's repository which you would like to build
-  "revision": "2020.11.358366026"
+  "revision": "2020.11.358366026",
+  // (Optional) Override for UBI8 image name and version
+  "ubi8Image": "nodejs-18:1-71",
+  // (Optional) Override for name and version of package manager
+  "packageManager": "npm@9.6.7",
+  // (Optional) Override for version of vsce
+  "vsceVersion": "2.17.0"
 }
 ```
 
@@ -24,6 +34,8 @@ Should you choose to contribute a `Dockerfile`, the following things are require
 * The `Dockerfile` must take the following build-time arguments (i.e. `ARG name`):
     * `extension_repository`
     * `extension_revision`
-    * `extension_name`
+    * `extension_image`
+    * `extension_manager`
+    * `extension_vsce`
 * The `vsix` file resulting from the build (inside the container) must be located at the root of the container, named `/name-revision.vsix` (where name and revision are the values of the build arg specified above)
 * A tarball of the extension's source code (prior to build) must be located at the root of the container, named `/name-revision-sources.tar.gz` (again, where name and revision are the values of the build arg specified above)

--- a/README.md
+++ b/README.md
@@ -12,19 +12,25 @@ Every extension in this repository builds inside a `ubi8` based Dockerfile. The 
 Every extension  **must** have an entry in `plugin-config.json` file. An example entry of a plugin in JSON is as follows:
 
 ```js
-
-atlassian.atlascode{
-  // Repository URL of the extension's git repository
-  "repository": "https://github.com/microsoft/vscode-python",
-  // The tag/SHA1-ID of the extension's repository which you would like to build
-  "revision": "2020.11.358366026",
-  // (Optional) Override for UBI8 image name and version
-  "ubi8Image": "nodejs-18:1-71",
-  // (Optional) Override for name and version of package manager
-  "packageManager": "npm@9.6.7",
-  // (Optional) Override for version of vsce
-  "vsceVersion": "2.17.0"
-}
+{
+...
+  "Plugins": {
+...
+    atlassian.atlascode: {
+      // Repository URL of the extension's git repository
+      "repository": "https://github.com/microsoft/vscode-python",
+      // The tag/SHA1-ID of the extension's repository which you would like to build
+      "revision": "2020.11.358366026",
+      // If true, plugin will be updateable during the /build/update-from-ovsx.sh script run
+      "update": true,
+      // (Optional) Override for UBI8 image name and version
+      "ubi8Image": "nodejs-18:1-71",
+      // (Optional) Override for name and version of package manager
+      "packageManager": "npm@9.6.7",
+      // (Optional) Override for version of vsce
+      "vsceVersion": "2.17.0"
+    },
+...
 ```
 
 Optionally, a `Dockerfile` that builds the extension can be provided inside the extension's folder. Note, this is only needed if the extension requires "special" dependencies to build. If no `Dockerfile` is found in the extensions's folder, then the "generic" `Dockerfile` (found at the root of this repository) will be used. In this case, the only thing needed is the folder matching the extension's name, and the `extension.json` file as outlined above.

--- a/atlassian.atlascode/Dockerfile
+++ b/atlassian.atlascode/Dockerfile
@@ -20,7 +20,7 @@ ARG extension_vsce
 USER root
 WORKDIR /
 
-RUN npm install -g npm@9.6.7 ${extension_manager} 
+RUN npm install -g ${extension_manager} 
 
 RUN mkdir ./${extension_name}-src && cd ./${extension_name}-src && \
     git clone ${extension_repository} ${extension_name} && \

--- a/plugin-config.json
+++ b/plugin-config.json
@@ -45,8 +45,7 @@
     "felixfbecker.php-debug": {
       "repository": "https://github.com/xdebug/vscode-php-debug",
       "revision": "v1.32.1",
-      "update": "true",
-      "ubi8Image": "nodejs-16:1-90"
+      "update": "true"
     },
     "github.vscode-pull-request-github": {
       "repository": "https://github.com/microsoft/vscode-pull-request-github",
@@ -66,7 +65,7 @@
     },
     "jfrog.jfrog-vscode-extension": {
       "repository": "https://github.com/jfrog/jfrog-vscode-extension",
-      "revision": "v2.7.1",
+      "revision": "2.7.1",
       "update": "true"
     },
     "llvm-vs-code-extensions.vscode-clangd": {
@@ -81,7 +80,7 @@
     },
     "ms-python.isort": {
       "repository": "https://github.com/microsoft/vscode-isort",
-      "revision": "2023.10.1",
+      "revision": "v2023.10.1",
       "update": "true"
     },
     "ms-python.black-formatter": {
@@ -100,8 +99,7 @@
       "repository": "https://github.com/microsoft/vscode-jupyter",
       "revision": "4733a075e8af70d358dba81987395c9150fe5802",
       "update": "false",
-      "ubi8Image": "nodejs-16:1-90",
-      "packageManager": "npm@6.14.18"
+      "packageManager": "npm@9.5.0"
     },
     "ms-toolsai.jupyter-keymap": {
       "comment": "Version: 1.1.2",
@@ -132,23 +130,20 @@
     "ms-vscode.js-debug": {
       "comment": "Needed for the devspaces-code build. Version must be kept in sync with  https://github.com/microsoft/vscode/blob/main/product.json#L35",
       "repository": "https://github.com/microsoft/vscode-js-debug",
-      "revision": "v1.82.0",
-      "update": "false",
-      "packageManager": "npm@9.6.7"
+      "revision": "v1.83.1",
+      "update": "false"
     },
     "ms-vscode.js-debug-companion": {
       "comment": "Needed for the devspaces-code build. Version must be kept in sync with  https://github.com/microsoft/vscode/blob/main/product.json#L35",
       "repository": "https://github.com/microsoft/vscode-js-debug-companion",
       "revision": "v1.1.2",
-      "update": "false",
-      "packageManager": "npm@9.6.7"
+      "update": "false"
     },
     "ms-vscode.vscode-js-profile-table": {
       "comment": "Needed for the devspaces-code build. Version must be kept in sync with  https://github.com/microsoft/vscode/blob/main/product.json#L35",
       "repository": "https://github.com/microsoft/vscode-js-profile-visualizer",
       "revision": "v1.0.3",
-      "update": "false",
-      "packageManager": "npm@9.6.7"
+      "update": "false"
     },
     "ms-dotnettools.vscode-dotnet-runtime": {
       "repository": "https://github.com/dotnet/vscode-dotnet-runtime",
@@ -169,7 +164,7 @@
     },
     "redhat.fabric8-analytics": {
       "repository": "https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension",
-      "revision": "0.7.0",
+      "revision": "v0.7.0",
       "update": "true",
       "packageManager": "npm@6.14.17"
     },
@@ -193,7 +188,7 @@
     },
     "redhat.vscode-openshift-connector": {
       "repository": "https://github.com/redhat-developer/vscode-openshift-tools",
-      "revision": "v1.8.0",
+      "revision": "1.8.0",
       "update": "true"
     },
     "redhat.vscode-quarkus": {

--- a/redhat.vscode-openshift-connector/Dockerfile
+++ b/redhat.vscode-openshift-connector/Dockerfile
@@ -22,9 +22,14 @@ WORKDIR ${HOME}
 
 RUN npm install -g ${extension_manager}
 
-RUN mkdir ./${extension_name}-src && cd ./${extension_name}-src && \
-    git clone ${extension_repository} ${extension_name} && \
-    cd ./${extension_name} && git checkout ${extension_revision} && \
+# build bug - if project path contain dots, it will cause one of dependencies to fail build:
+# https://github.com/redhat-developer/vscode-openshift-tools/issues/3527
+# since `extension_name` contains one, a `workaround_path` variable will be used
+# once the bug is fixed, workaround path can be replaced back with extension_name
+ENV workaround_path="vscode-openshift-connector"
+RUN mkdir ./${workaround_path}-src && cd ./${workaround_path}-src && \
+    git clone ${extension_repository} ${workaround_path} && \
+    cd ./${workaround_path} && git checkout ${extension_revision} && \
     rm -rf ./.git && tar -czvf ${HOME}/${extension_name}-sources.tar.gz ./ && \
     npm install -g @vscode/vsce@${extension_vsce} gulp-cli@2.3.0 && \
     if [[ -f yarn.lock ]]; then yarn install; \


### PR DESCRIPTION
This PR contains multiple fixes and updates:
- update README.md with relevant information about the project
- added archives to .gitignore.
- most of extensions were not buildable, because current ubi8image `nodejs18:1-60` comes with a version that doesn't work with the `latest` version of npm. So it will be updated to the newer version `nodejs-18:1-71.1698060565`
- with that, some more extensions started to fail their build on newer image, because of `too many open files` error in npm. Because new image now features limits set in them, a `ulimit` override flag was added to `podman build` 
- build.sh script will not update manifests in `plugin-manifest.json`, unless new flag `--update-manifest` is set.It should make for a better developers workflow. who while trying to build these plugins locally would rather not want to create & commit changes to manifest, as only the Jenkins job should do it, when it builds them after merges to main branch.
- buiild.sh script `--clean` flag is updated, instead of doing system prune, it would just remove the final builder image, and base layer images won't have to be redownloaded, when developers/Jenkins are building more than 1 plugin. 
- update `project-config.json` with newer revisions, that were not reachable anymore

this PR has to be merged in conjunction with another DS Jenkins PR https://gitlab.cee.redhat.com/codeready-workspaces/crw-jenkins/-/merge_requests/1746