### PR TITLE
fix: workaround incorrect version in js-profile-table sources

### DIFF
--- a/ms-vscode.vscode-js-profile-table/Dockerfile
+++ b/ms-vscode.vscode-js-profile-table/Dockerfile
@@ -31,4 +31,6 @@ RUN mkdir ./${extension_name}-src && cd ./${extension_name}-src && \
     rm -rf ./.git && tar -czvf /${extension_name}-sources.tar.gz ./ && \
     npm run compile && \
     cd ./packages/vscode-js-profile-table && cp ../../LICENSE ./ && \
+    #next line is needed for 1.0.8 version, which wrongfully contains 1.0.7 version in its sources
+    npm --no-git-tag-version version --allow-same-version ${extension_revision#v} && \
     vsce package --out /${extension_name}.vsix --no-dependencies


### PR DESCRIPTION
JS Profile Table 1.0.8, which is a built in dependency for Che/DS Code, has a problem - in its sources, [the version 1.0.7 is listed ](https://github.com/microsoft/vscode-js-profile-visualizer/blob/v1.0.8/packages/vscode-js-profile-table/package.json). Which means building it from sources as is, will create a VSIX with 1.0.7 version, which will crash the build, that expects 1.0.8 version.

To workaround that, I added a "just-in-case" overwrite of version in package.json