### PR TITLE
chore: bump java ext; fix build

### DIFF
--- a/plugin-config.json
+++ b/plugin-config.json
@@ -171,10 +171,10 @@
     },
     "redhat.java": {
       "repository": "https://github.com/redhat-developer/vscode-java",
-      "revision": "v1.27.0",
+      "revision": "v1.32.0",
       "update": "true",
-      "ubi8Image": "nodejs-14:1-101",
-      "packageManager": "npm@6.14.17"
+      "ubi8Image": "nodejs-18:1-114",
+      "packageManager": "npm@9.6.7"
     },
     "redhat.vscode-commons": {
       "comment": "Version: 0.0.6",

--- a/redhat.java/Dockerfile
+++ b/redhat.java/Dockerfile
@@ -20,8 +20,9 @@ ARG extension_vsce
 USER root
 WORKDIR /
 
-ENV JDT_VERSION="v1.23.0"
+ENV JDT_VERSION="v1.37.0"
 
+RUN dnf -y install wget
 RUN npm install -g ${extension_manager}
 
 RUN mkdir ./${extension_name}-src && cd ./${extension_name}-src && \
@@ -34,10 +35,13 @@ RUN mkdir ./${extension_name}-src && cd ./${extension_name}-src && \
     cd ./${extension_name} && git checkout ${extension_revision} && \
     #Copy quarkus source into extension source to package both
     cp /eclipse.jdt.ls-${JDT_VERSION}-sources.tar.gz ./ && \
-    npm install -g @vscode/vsce@${extension_vsce} gulp-cli@2.3.0 && \
+    wget http://download.eclipse.org/jdtls/snapshots/jdt-language-server-latest.tar.gz && \
+    mkdir server && tar -xvzf jdt-language-server-latest.tar.gz -C ./server --no-same-owner && rm jdt-language-server-latest.tar.gz && \
+    npm install -g @vscode/vsce@${extension_vsce} && \
     if [[ -f yarn.lock ]]; then yarn install; \
     else npm install --unsafe-perm=true --allow-root; fi && \
     rm -rf ./.git && tar -czvf /${extension_name}-sources.tar.gz ./ && \
+    npx gulp download_lombok && \
     npm run compile && \
     npm run vscode:prepublish && \
     vsce package --out /${extension_name}.vsix


### PR DESCRIPTION
-  Bump version of redhat.java extension to 1.32.0
-  Fix build of the extension

Related issue: https://issues.redhat.com/browse/CRW-6298