### PR TITLE
fix: Fix build of the ms-vscode.js-debug extension

### DIFF
--- a/ms-vscode.js-debug/Dockerfile
+++ b/ms-vscode.js-debug/Dockerfile
@@ -9,7 +9,7 @@
 
 ARG extension_image
 
-FROM registry.access.redhat.com/ubi8/${extension_image}
+FROM registry.access.redhat.com/ubi9/nodejs-20:9.5
 
 ARG extension_repository
 ARG extension_revision


### PR DESCRIPTION
Build of the `ms-vscode.js-debug` extension is failing with the following error:
```
/ms-vscode.js-debug-src/ms-vscode.js-debug/node_modules/dprint/dprint: /lib64/libm.so.6: version `GLIBC_2.29' not found (required by /ms-vscode.js-debug-src/ms-vscode.js-debug/node_modules/dprint/dprint)
```
At the moment:
- `ubi8/nodejs-18:1-102` is used to build the extension.
- `ubi8/nodejs-18:1-102` image contains GLIBC `2.28`
- `ms-vscode.js-debug` requires GLIBC `2.29`

I didn't find `ubi8`-based image with the corresponding `GLIBC` version, 
so I propose to try `ubi9`-based image - it contains `2.34`version.  