### PR TITLE
fix: Fix build of the ms-vscode.js-debug extension

### DIFF
--- a/ms-vscode.js-debug/Dockerfile
+++ b/ms-vscode.js-debug/Dockerfile
@@ -9,7 +9,7 @@
 
 ARG extension_image
 
-FROM registry.access.redhat.com/ubi8/${extension_image}
+FROM registry.access.redhat.com/ubi9/nodejs-20:9.5
 
 ARG extension_repository
 ARG extension_revision


### PR DESCRIPTION
See https://github.com/redhat-developer/devspaces-vscode-extensions/pull/85