### PR TITLE
fix: Fix build extensions that use default ubi8 image tag

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -53,7 +53,7 @@ EXTENSION_REPOSITORY=$(parse_json repository)
 EXTENSION_REVISION=$(parse_json revision)
 
 #Defaults
-ubi8Image="nodejs-18:1-102"
+ubi8Image="nodejs-20:1-73"
 packageManager="npm@latest"
 vsceVersion="2.26.0"
 


### PR DESCRIPTION
See https://issues.redhat.com/browse/CRW-8332.
The cause of the problem is:
```
npm ERR! notsup Required: {"node":"^20.17.0 || >=22.9.0"}
npm ERR! notsup Actual:   {"npm":"10.2.4","node":"v18.19.1"}
```


So, I believe it's time to bump Node.js version.