### PR TITLE
Fix version for the js-debug extension

### DIFF
--- a/ms-vscode.js-debug/Dockerfile
+++ b/ms-vscode.js-debug/Dockerfile
@@ -25,6 +25,13 @@ RUN npm install -g ${extension_manager}
 RUN mkdir ./${extension_name}-src && cd ./${extension_name}-src && \
     git clone ${extension_repository} ${extension_name} && \
     cd ./${extension_name} && git checkout ${extension_revision} && \
+    # workaround for the https://github.com/microsoft/vscode-js-debug/issues/2195
+    # should be removed when version in upstream is updated 
+    current_version=$(node -p "require('./package.json').version") && \
+    if [ "$extension_revision" = "v1.97.1" ] && [ "$current_version" = "1.97.0" ]; then \
+        npm version 1.97.1 --no-git-tag-version; \
+        echo "Version was updated to 1.97.1"; \
+    fi; \
     npm install -g @vscode/vsce@${extension_vsce} gulp-cli@2.3.0 && \
     if [[ -f yarn.lock ]]; then yarn install; \
     else npm install --unsafe-perm=true --allow-root; fi && \


### PR DESCRIPTION
For some reason `1.97.1` tag of the `ms-vscode.js-debug` extension contains `1.97.0` value for the version field of the package.json file. Please see https://github.com/microsoft/vscode-js-debug/blob/v1.97.1/package.json#L4.

I created an issue in the corresponding repository, but unfortunately, there is no response.
At the same time we have a failed build on the jenkins because of this problem.

So, my proposal is:
 - let's workaround it on our side   
 - I'm going keep an eye on the upstream issue and remove this workaround as soon as possible
 - I also added reference to the upstream issue directly to the dockerfile 
